### PR TITLE
Add CORS to allow everything

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from typing import List, Dict
 from langchain_core.messages import HumanMessage, AIMessage
 from assistant import initialize_assistant
+from fastapi.middleware.cors import CORSMiddleware
 
 # Load environment variables
 load_dotenv()
@@ -21,6 +22,15 @@ app = FastAPI(
     title="AI Conversation Coach API",
     description="Provides AI-powered feedback on user communication.",
     version="1.1.1"
+)
+
+# Add CORS middleware to allow all origins, methods, and headers
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # Request Models (HistoryMessage remains, CoachingResponse is removed)


### PR DESCRIPTION
Add CORS middleware to allow all origins, methods, and headers.

* Import `CORSMiddleware` from `fastapi.middleware.cors` in `app.py`.
* Add `CORSMiddleware` to the FastAPI app to allow all origins, methods, and headers in `app.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/converse-backend-ai/pull/1?shareId=b8fdda51-a610-4eb8-9915-3ca7930e526d).